### PR TITLE
Large code refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ The defined fields are:
 |---------------|---------|-------------------------------------------------------------------------------------------------------------------|
 | callback      | function| the callback function - same as `fn` passed to `get_user_input()` - can be set to a different function to modify the callback |
 | passthrough_args | table| an array of extra arguments to pass to the callback - cannot be `nil`                                             |
-| cancel        | method  | cancels the request - unlike `cancel_user_input()` this does not cancel all requests with a matching id |
+| pending       | boolean | true if the request is still pending, false if the request is completed                                           |
+| cancel        | method  | cancels the request - unlike `cancel_user_input()` this does not cancel all requests with a matching id           |
 
 A method is referring to a function that is called with Lua's method syntax:
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ The following error codes currently exist:
 ```properties
     exited          the user closed the input instead of pressing Enter
     already_queued  a request with the specified id was already in the queue
-    cancelled       the request was cancelled 
+    cancelled       the request was cancelled
+    replaced        request was replaced
 ```
 
 If the request throws an error for whatever reason then that Lua error message will be returned instead.
@@ -74,6 +75,7 @@ The following options are currently available:
 | default_input | string  |                           | text to pre-enter into the input                                                                                  |
 | cursor_pos    | number  | 1                         | the numerical position to place the cursor - for use with the default_input field                                 |
 | queueable     | boolean | false                     | allows request to be queued even if there is already one queued with the same id                                  |
+| replace       | boolean | false                     | replace all queued requests with the same id with the new request                                                 |
 
 The function prepends the script name to any id to avoid conflicts, but the actual script has no way to determining where the requests come from,
 so make sure that the function is used.

--- a/README.md
+++ b/README.md
@@ -54,18 +54,18 @@ The following options are currently available:
 | request_text  | string  | `requesting user input:`  | printed above the input box - use it to describe the input request                                                |
 | default_input | string  |                           | text to pre-enter into the input                                                                                  |
 | cursor_pos    | number  | 1                         | the numerical position to place the cursor - for use with the default_input field                                 |
-| queueable     | boolean | false                     | allow request if another request with the same id is already queued                                               |
-| replace       | boolean | false                     | replace the first existing request with the same id - otherwise add to the back like normal - overrides queueable |
+| queueable     | boolean | false                     | allows request to be queued even if there is already one queued with the same id                                  |
 
 The function prepends the script name to any id to avoid conflicts, but the actual script has no way to determining where the requests come from,
 so make sure that the function is used.
 
-Also note that the `queueable` and `replace` flags apply to the incoming requests, not requests that already exist in the queue.
+The `replace` flag has been removed in an effort to simplify the backend of the script.
+To replicate `replace` you can use `cancel_user_input` before making the request.
 
 ### `cancel_user_input([id])`
 
 Removes all input requests with a matching string id.
-If no id is provided, then the script's name - as returned by `mp.get_script_name()` - will be used.
+If no id is provided, then the default id for `get_user_input()` will be used.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Create these directories if they do not exist. `~~/` represents the mpv config d
 What is important is that `user-input.lua` is loaded as a script my mpv, which can be done from anywhere using the `--script` option.
 Meanwhile, `user-input-module.lua` needs to be in one of the lua package paths; scripts that use this API are recommended to use `~~/script-modules/`, but you can set any directory using the `LUA_PATH` environment variable.
 
-## Interface Functions
+## Interface Functions - v0.1.0
 
 Note: this API is still in its early stages, so these functions may change.
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,22 @@ If no id is provided, then the default id for `get_user_input()` will be used.
 
 The cancellation happens asynchronously.
 
+### `get_user_input_co([options [, co_resume]])`
+
+This is a wrapper function around `get_user_input()` that uses [coroutines](https://www.lua.org/manual/5.1/manual.html#2.11)
+to make the input request behave synchronously. It returns `line, err`, as would
+normally be passed to the callback function.
+
+This function will yield the current coroutine and resume once the input
+response has been received. If the coroutine is forcibly resumed by the user then
+it will send a cancellation request to `user-input` and will return `nil, 'cancelled'`.
+The request object is passed to the yield function.
+
+If a function is passed as co_resume then custom resume behaviour can be setup instead
+of the default `coroutine.resume`.
+This function is passed `uid, line, err` where `uid` is a unique variable that needs to be
+passed to the resume. The functions created by `coroutine.wrap` will work.
+
 ## Examples
 
 The [examples](/examples) folder contains some scripts that make user of the API.

--- a/README.md
+++ b/README.md
@@ -38,9 +38,8 @@ Any additional arguments sent after the options table will be sent to fn as addi
 
 The following error codes currently exist:
 
-    exitted         the user closed the input instead of pressing Enter
+    exited         the user closed the input instead of pressing Enter
     already_queued  a request with the specified id was already in the queue
-    replaced        the request was replaced with a newer request
     cancelled       a script cancelled the request
 
 #### options

--- a/README.md
+++ b/README.md
@@ -38,9 +38,11 @@ Any additional arguments sent after the options table will be sent to fn as addi
 
 The following error codes currently exist:
 
-    exited         the user closed the input instead of pressing Enter
+    exited          the user closed the input instead of pressing Enter
     already_queued  a request with the specified id was already in the queue
     cancelled       a script cancelled the request
+
+If the request throws an error for whatever reason then the error message will be returned instead.
 
 #### options
 

--- a/README.md
+++ b/README.md
@@ -74,11 +74,12 @@ The following options are currently available:
 | request_text  | string  | `requesting user input:`  | printed above the input box - use it to describe the input request                                                |
 | default_input | string  |                           | text to pre-enter into the input                                                                                  |
 | cursor_pos    | number  | 1                         | the numerical position to place the cursor - for use with the default_input field                                 |
-| queueable     | boolean | false                     | allows request to be queued even if there is already one queued with the same id                                  |
-| replace       | boolean | false                     | replace all queued requests with the same id with the new request                                                 |
+| queueable     | boolean | false                     | allows requests to be queued even if there is already one queued with the same id                                 |
+| replace       | boolean | false                     | replace the queued request with the same id with the new request                                                      |
 
-The function prepends the script name to any id to avoid conflicts, but the actual script has no way to determining where the requests come from,
-so make sure that the function is used.
+The function prepends the script name to any id to avoid conflicts between
+different scripts.
+Do not use both the `queuable` and `replace` flags for input requests with the same ID, the behaviour is undefined and may change at any time.
 
 Here is an example for printing only a sucessful input:
 

--- a/README.md
+++ b/README.md
@@ -99,11 +99,15 @@ The defined fields are:
 | passthrough_args | table| an array of extra arguments to pass to the callback - cannot be `nil`                                             |
 | pending       | boolean | true if the request is still pending, false if the request is completed                                           |
 | cancel        | method  | cancels the request - unlike `cancel_user_input()` this does not cancel all requests with a matching id           |
+| update        | method  | takes an options table and updates the request - maintains the original request unlike the `replace` flag - not all options can be changed |
 
 A method is referring to a function that is called with Lua's method syntax:
 
 ```lua
 local request = input.get_user_input(print)
+request:update{
+    request_text = "hello world:"
+}
 request:cancel()
 ```
 

--- a/user-input-module.lua
+++ b/user-input-module.lua
@@ -11,10 +11,17 @@
 ]]
 
 local mp = require 'mp'
+local utils = require 'mp.utils'
 local mod = {}
 
 local name = mp.get_script_name()
 local counter = 1
+
+local function pack(...)
+    local t = {...}
+    t.n = select("#", ...)
+    return t
+end
 
 -- sends a request to ask the user for input using formatted options provided
 -- creates a script message to recieve the response and call fn
@@ -23,24 +30,22 @@ function mod.get_user_input(fn, options, ...)
     local response_string = name.."/__user_input_request/"..counter
     counter = counter + 1
 
-    local passthrough_args = ... and {...} or nil
+    local passthrough_args = pack(...)
 
     -- create a callback for user-input to respond to
     mp.register_script_message(response_string, function(input, err)
         mp.unregister_script_message(response_string)
-        fn(err == "" and input or nil, err, passthrough_args and unpack(passthrough_args))
+        fn(err == "" and input or nil, err, unpack(passthrough_args, 1, passthrough_args.n))
     end)
 
     -- send the input command
-    mp.commandv("script-message-to", "user_input", "request-user-input",
-        response_string,
-        name .. '/' .. (options.id or ""),      -- id code for the request
-        "["..(options.source or name).."] "..(options.request_text or options.text or ("requesting user input:")),
-        options.default_input or "",
-        options.queueable and "1" or "0",
-        options.replace and "1" or "0",
-        options.cursor_pos or 1
-    )
+    mp.commandv("script-message-to", "user_input", "request-user-input", utils.format_json({
+        id = name..'/'..(options.id or ""),
+        response = response_string,
+        request_text = ("[%s] %s"):format(options.source or name, options.request_text or options.text or "requesting user input:"),
+        default_input = options.default_input,
+        cursor_pos = options.cursor_pos
+    }))
 end
 
 -- sends a request to cancel all input requests with the given id

--- a/user-input-module.lua
+++ b/user-input-module.lua
@@ -47,7 +47,8 @@ function mod.get_user_input(fn, options, ...)
         response = response_string,
         request_text = ("[%s] %s"):format(options.source or name, options.request_text or options.text or "requesting user input:"),
         default_input = options.default_input,
-        cursor_pos = options.cursor_pos
+        cursor_pos = options.cursor_pos,
+        queueable = options.queueable and true
     })))
 end
 

--- a/user-input-module.lua
+++ b/user-input-module.lua
@@ -10,6 +10,8 @@
     these requests will remain the same for future versions of user-input.
 ]]
 
+local API_VERSION = "0.1.0"
+
 local mp = require 'mp'
 local utils = require 'mp.utils'
 local mod = {}
@@ -42,6 +44,7 @@ function mod.get_user_input(fn, options, ...)
 
     -- send the input command
     mp.commandv("script-message-to", "user_input", "request-user-input", (utils.format_json({
+        version = API_VERSION,
         id = name..'/'..(options.id or ""),
         source = name,
         response = response_string,

--- a/user-input-module.lua
+++ b/user-input-module.lua
@@ -76,7 +76,7 @@ function mod.get_user_input(fn, options, ...)
         request.pending = false
 
         response = utils.parse_json(response)
-        request.callback(response.line, response.err, unpack(request.passthrough_args, 1, request.passthrough_args.n or #request.passthrough_args))
+        request.callback(response.line, response.err, unpack(request.passthrough_args, 1, request.passthrough_args.n))
     end)
 
     -- send the input command

--- a/user-input-module.lua
+++ b/user-input-module.lua
@@ -39,14 +39,18 @@ function mod.get_user_input(fn, options, ...)
     local response_string = name.."/__user_input_request/"..counter
     counter = counter + 1
 
-    local passthrough_args = pack(...)
+    local request = {
+        uid = response_string,
+        passthrough_args = pack(...),
+        callback = fn
+    }
 
     -- create a callback for user-input to respond to
     mp.register_script_message(response_string, function(response)
         mp.unregister_script_message(response_string)
 
         response = utils.parse_json(response)
-        fn(response.line, response.err, unpack(passthrough_args, 1, passthrough_args.n))
+        request.callback(response.line, response.err, unpack(request.passthrough_args, 1, request.passthrough_args.n or #request.passthrough_args))
     end)
 
     -- send the input command
@@ -60,10 +64,6 @@ function mod.get_user_input(fn, options, ...)
         cursor_pos = options.cursor_pos,
         queueable = options.queueable and true
     })))
-
-    local request = {
-        uid = response_string
-    }
 
     return setmetatable(request, { __index = request_mt })
 end

--- a/user-input-module.lua
+++ b/user-input-module.lua
@@ -25,6 +25,13 @@ local function pack(...)
     return t
 end
 
+local request_mt = {}
+
+function request_mt:cancel()
+    assert(self.uid, "request object missing UID")
+    mp.commandv("script-message-to", "user_input", "cancel-user-input/uid", self.uid)
+end
+
 -- sends a request to ask the user for input using formatted options provided
 -- creates a script message to recieve the response and call fn
 function mod.get_user_input(fn, options, ...)
@@ -53,12 +60,18 @@ function mod.get_user_input(fn, options, ...)
         cursor_pos = options.cursor_pos,
         queueable = options.queueable and true
     })))
+
+    local request = {
+        uid = response_string
+    }
+
+    return setmetatable(request, { __index = request_mt })
 end
 
 -- sends a request to cancel all input requests with the given id
 function mod.cancel_user_input(id)
     id = name .. '/' .. (id or "")
-    mp.commandv("script-message-to", "user_input", "cancel-user-input", id)
+    mp.commandv("script-message-to", "user_input", "cancel-user-input/id", id)
 end
 
 return mod

--- a/user-input-module.lua
+++ b/user-input-module.lua
@@ -65,7 +65,8 @@ function mod.get_user_input(fn, options, ...)
         request_text = ("[%s] %s"):format(options.source or name, options.request_text or options.text or "requesting user input:"),
         default_input = options.default_input,
         cursor_pos = options.cursor_pos,
-        queueable = options.queueable and true
+        queueable = options.queueable and true,
+        replace = options.replace and true
     })))
 
     return setmetatable(request, { __index = request_mt })

--- a/user-input-module.lua
+++ b/user-input-module.lua
@@ -42,12 +42,14 @@ function mod.get_user_input(fn, options, ...)
     local request = {
         uid = response_string,
         passthrough_args = pack(...),
-        callback = fn
+        callback = fn,
+        pending = true
     }
 
     -- create a callback for user-input to respond to
     mp.register_script_message(response_string, function(response)
         mp.unregister_script_message(response_string)
+        request.pending = false
 
         response = utils.parse_json(response)
         request.callback(response.line, response.err, unpack(request.passthrough_args, 1, request.passthrough_args.n or #request.passthrough_args))

--- a/user-input-module.lua
+++ b/user-input-module.lua
@@ -33,19 +33,22 @@ function mod.get_user_input(fn, options, ...)
     local passthrough_args = pack(...)
 
     -- create a callback for user-input to respond to
-    mp.register_script_message(response_string, function(input, err)
+    mp.register_script_message(response_string, function(response)
         mp.unregister_script_message(response_string)
-        fn(err == "" and input or nil, err, unpack(passthrough_args, 1, passthrough_args.n))
+
+        response = utils.parse_json(response)
+        fn(response.line, response.err, unpack(passthrough_args, 1, passthrough_args.n))
     end)
 
     -- send the input command
-    mp.commandv("script-message-to", "user_input", "request-user-input", utils.format_json({
+    mp.commandv("script-message-to", "user_input", "request-user-input", (utils.format_json({
         id = name..'/'..(options.id or ""),
+        source = name,
         response = response_string,
         request_text = ("[%s] %s"):format(options.source or name, options.request_text or options.text or "requesting user input:"),
         default_input = options.default_input,
         cursor_pos = options.cursor_pos
-    }))
+    })))
 end
 
 -- sends a request to cancel all input requests with the given id

--- a/user-input.lua
+++ b/user-input.lua
@@ -660,10 +660,10 @@ end
 
 co = coroutine.create(driver)
 
--- removes all requests with the specified id from the queue
-mp.register_script_message("cancel-user-input", function(id)
+--cancels any input request that returns true for the given predicate function
+local function cancel_input_request(pred)
     for i = #queue, 1, -1 do
-        if queue[i].id == id then
+        if pred(i) then
             req = remove_request(i)
             send_response{ err = "cancelled", response = req.response, source = req.source }
 
@@ -678,6 +678,15 @@ mp.register_script_message("cancel-user-input", function(id)
             end
         end
     end
+end
+
+mp.register_script_message("cancel-user-input/uid", function(uid)
+    cancel_input_request(function(i) return queue[i].response == uid end)
+end)
+
+-- removes all requests with the specified id from the queue
+mp.register_script_message("cancel-user-input/id", function(id)
+    cancel_input_request(function(i) return queue[i].id == id end)
 end)
 
 --the function that parses the input requests

--- a/user-input.lua
+++ b/user-input.lua
@@ -669,7 +669,13 @@ mp.register_script_message("cancel-user-input", function(id)
 
             --if we're removing the first item then that means the coroutine is waiting for a response
             --we will need to tell the coroutine to resume, upon which it will move to the next request
-            if i == 1 then coroutine.resume(co) end
+            --if there is something in the buffer then save it to the history before erasing it
+            if i == 1 then
+                local old_line = line
+                if old_line ~= "" then table.insert(histories[req.id].list, old_line) end
+                clear()
+                coroutine.resume(co)
+            end
         end
     end
 end)

--- a/user-input.lua
+++ b/user-input.lua
@@ -682,13 +682,13 @@ end)
 
 --the function that parses the input requests
 local function input_request(req)
-    if not req.version then return msg.error("input requests require an API version string") end
+    assert(req.version, "input requests require an API version string")
     if not string.find(req.version, API_MAJOR_MINOR, 1, true) then
-        return msg.error(("input request has invalid version: expected %s.x, got %s"):format(API_MAJOR_MINOR, req.version))
+        error(("input request has invalid version: expected %s.x, got %s"):format(API_MAJOR_MINOR, req.version))
     end
 
-    if not req.response then return msg.error("input requests require a response string") end
-    if not req.id then return msg.error("input requests require an id string") end
+    assert(req.response, "input requests require a response string")
+    assert(req.id, "input requests require an id string")
 
     req.text = ass_escape(req.request_text or "")
     req.default_input = req.default_input or ""

--- a/user-input.lua
+++ b/user-input.lua
@@ -693,8 +693,6 @@ local function input_request(req)
         if cursor_pos < 1 then cursor_pos = 1
         elseif cursor_pos > #req.default_input then cursor_pos = #req.default_input end
         req.cursor_pos = cursor_pos
-    else
-        req.cursor_pos = 1
     end
 
     if not histories[req.id] then histories[req.id] = {pos = 1, list = {}} end

--- a/user-input.lua
+++ b/user-input.lua
@@ -18,6 +18,9 @@ local opts = {
 
 options.read_options(opts, "user_input")
 
+local API_VERSION = "0.1.0"
+local API_MAJOR_MINOR = API_VERSION:match("%d+%.%d+")
+
 local co = nil
 local queue  = {}
 local active_ids = {}
@@ -674,8 +677,13 @@ end)
 
 --the function that parses the input requests
 local function input_request(req)
-    if not req.response then msg.error("input requests require a response string") ; return end
-    if not req.id then msg.error("input requests require an id string") ; return end
+    if not req.version then return msg.error("input requests require an API version string") end
+    if not string.find(req.version, API_MAJOR_MINOR, 1, true) then
+        return msg.error(("input request has invalid version: expected %s.x, got %s"):format(API_MAJOR_MINOR, req.version))
+    end
+
+    if not req.response then return msg.error("input requests require a response string") end
+    if not req.id then return msg.error("input requests require an id string") end
 
     req.text = ass_escape(req.request_text or "")
     req.default_input = req.default_input or ""

--- a/user-input.lua
+++ b/user-input.lua
@@ -38,8 +38,7 @@ local line = ''
         removed support for log messages, sending commands, tab complete, help commands
         removed update timer
         Changed esc key to call handle_esc function
-        handle_esc and handle_enter now call the send_response() function
-        all functions that send responses now call queue:pop()
+        handle_esc and handle_enter now resume the main coroutine with a response table
         made history specific to request ids
         localised all functions - reordered some to fit
         keybindings use new names


### PR DESCRIPTION
This is primarily a code refactor for the backend of the script.
Moves to using JSON for script-messages to simplify the increasingly
long argument lists. Also switched the messy queue code to use an
infinitely looping coroutine, which makes the logic much clearer.

This PR is not backwards compatible, it corrects
the spelling of the `exited` error flag.

This PR also adds API versioning which will warn the user
if user-input and user-input-module are not at the same version.

The `get_user_input()` function now returns a request table
that provides some useful values and methods.